### PR TITLE
remove `http_access allow all`

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,6 @@ Open the `squid.conf` file:
 ```bash
 sudo nano /etc/squid/squid.conf
 ```
-Search for `http_access deny all` and change it to `http_access allow all`.
 
 Then add these lines to the file:
 ```


### PR DESCRIPTION
hey, `http_access allow all` line in `squid.conf` makes the host being used by millions of bots after it is getting scanned as an open proxy.
you can see these connections in squid logs (`/var/log/squid/access.log`). it may downgrade the server performance.

on top of that, such configuration is forbidden by majority of server providers (and can get you banned without refund).

**not** using this line still works fine in my personal setup (`using firefox selenium runner`), but should work for every other runner - like puppeteer - as well.